### PR TITLE
fix problem of float values detected with grid2op>=1.5

### DIFF
--- a/leap_net/proxy/ProxyBackend.py
+++ b/leap_net/proxy/ProxyBackend.py
@@ -97,7 +97,7 @@ class ProxyBackend(BaseProxy):
                                "Please set \"train_batch_size\" and \"eval_batch_size\" to 1.")
         res = self._bk_act_class()
         act = self._act_class()
-        act.update({"set_bus": self._my_x[self._indx_var["topo_vect"]][0, :],
+        act.update({"set_bus": self._my_x[self._indx_var["topo_vect"]][0, :].astype(int),
                     "injection": {
                         "prod_p": self._my_x[self._indx_var["prod_p"]][0, :],
                         "prod_v": self._my_x[self._indx_var["prod_v"]][0, :],


### PR DESCRIPTION
With grid2op>=1.5, an exception is raised when running for ex.  evaluate_proxy_case_14.py:

Traceback (most recent call last):
  File "/home/jerome/venv/systemx/lib/python3.8/site-packages/grid2op/Action/BaseAction.py", line 3002, in set_bus
    self._aux_affect_object_int(values, "", self.dim_topo, None,
  File "/home/jerome/venv/systemx/lib/python3.8/site-packages/grid2op/Action/BaseAction.py", line 2669, in _aux_affect_object_int
    raise IllegalAction(f"{name_el}_id should be integers you provided float!")
grid2op.Exceptions.IllegalActionExceptions.IllegalAction: Grid2OpException IllegalAction "_id should be integers you provided float!"

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "evaluate_proxy_case_14.py", line 194, in <module>
    main()
  File "evaluate_proxy_case_14.py", line 73, in main
    agent_with_proxy_dc.evaluate(env,
  File "/home/jerome/venv/systemx/lib/python3.8/site-packages/leap_net/proxy/AgentWithProxy.py", line 326, in evaluate
    predictions = self._proxy.predict(force=self.global_iter == total_evaluation_step)
  File "/home/jerome/venv/systemx/lib/python3.8/site-packages/leap_net/proxy/BaseProxy.py", line 592, in predict
    data = self._extract_data(np.arange(self._last_id_eval, self._global_iter) % self.max_row_training_set)
  File "/home/jerome/venv/systemx/lib/python3.8/site-packages/leap_net/proxy/ProxyBackend.py", line 100, in _extract_data
    act.update({"set_bus": self._my_x[self._indx_var["topo_vect"]][0, :],
  File "/home/jerome/venv/systemx/lib/python3.8/site-packages/grid2op/Action/BaseAction.py", line 1513, in update
    self._digest_setbus(dict_)
  File "/home/jerome/venv/systemx/lib/python3.8/site-packages/grid2op/Action/BaseAction.py", line 1176, in _digest_setbus
    self.set_bus = dict_["set_bus"]
  File "/home/jerome/venv/systemx/lib/python3.8/site-packages/grid2op/Action/BaseAction.py", line 3008, in set_bus
    raise IllegalAction(f"Impossible to modify the bus with your input. "
grid2op.Exceptions.IllegalActionExceptions.IllegalAction: Grid2OpException IllegalAction "Impossible to modify the bus with your input. Please consult the documentation. The error was:
"Grid2OpException IllegalAction "_id should be integers you provided float!"""
